### PR TITLE
Add CSRF protection to budget management forms

### DIFF
--- a/src/main/resources/templates/budgets/list.html
+++ b/src/main/resources/templates/budgets/list.html
@@ -65,6 +65,7 @@
             <h1><i class="bi bi-piggy-bank me-2"></i>Budgets</h1>
             <div class="btn-group" role="group">
                 <form th:action="@{/budgets/cleanup-expired}" method="post" class="d-inline">
+                    <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
                     <button type="submit" class="btn btn-outline-warning">
                         <i class="bi bi-clock-history"></i> Cleanup Expired
                     </button>
@@ -192,12 +193,14 @@
                                             <i class="bi bi-pencil"></i>
                                         </a>
                                         <form th:action="@{/budgets/{id}/deactivate(id=${budget.id})}" method="post" class="d-inline">
+                                            <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
                                             <button type="submit" class="btn btn-outline-secondary btn-sm" 
                                                     onclick="return confirm('Deactivate this budget?')">
                                                 <i class="bi bi-pause"></i>
                                             </button>
                                         </form>
                                         <form th:action="@{/budgets/{id}/delete(id=${budget.id})}" method="post" class="d-inline">
+                                            <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
                                             <button type="submit" class="btn btn-outline-danger btn-sm" 
                                                     onclick="return confirm('Are you sure you want to delete this budget?')">
                                                 <i class="bi bi-trash"></i>
@@ -253,6 +256,7 @@
                                             <i class="bi bi-eye"></i>
                                         </a>
                                         <form th:action="@{/budgets/{id}/delete(id=${budget.id})}" method="post" class="d-inline">
+                                            <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
                                             <button type="submit" class="btn btn-outline-danger" 
                                                     onclick="return confirm('Are you sure you want to delete this budget?')">
                                                 <i class="bi bi-trash"></i>


### PR DESCRIPTION
Implement CSRF protection for budget management forms to enhance security against cross-site request forgery attacks.